### PR TITLE
let Fuzzurl.from_string/1 propagate the :error

### DIFF
--- a/lib/fuzzyurl.ex
+++ b/lib/fuzzyurl.ex
@@ -309,9 +309,8 @@ defmodule Fuzzyurl do
   """
   @spec from_string(String.t, [tuple]) :: Fuzzyurl.t
   def from_string(string, opts \\ []) when is_binary(string) do
-    {:ok, fuzzy_url} = Strings.from_string(string, opts)
-    fuzzy_url
+    with {:ok, fuzzy_url} <- Strings.from_string(string, opts),
+    do: fuzzy_url
   end
-
 end
 

--- a/test/fuzzyurl_test.exs
+++ b/test/fuzzyurl_test.exs
@@ -37,6 +37,11 @@ defmodule FuzzyurlTest do
       fu = %Fuzzyurl{protocol: "http", hostname: "example.com", path: "/index.html"}
       assert(fu == Fuzzyurl.from_string("http://example.com/index.html"))
     end
+
+    it "fails with an error tuple if string can't be parsed" do
+      assert {:error, message} = Fuzzyurl.from_string("http:\\\\in.valid")
+      assert message == "input string couldn't be parsed"
+    end
   end
 
   context "to_string" do


### PR DESCRIPTION
When calling `Fuzzyurl.from_string/1` you'll get a 
```
** (MatchError) no match of right hand side value: {:error, "input string couldn't be parsed"}
```
when calling with an unparseable string, while `Strings.from_string` actually returns the error in a tuple. 

This PR just propagates this error with message to the public API. 