### PR TITLE
raise ArgumentError when Fuzzyurl.from_string/1 gets bad input

### DIFF
--- a/lib/fuzzyurl.ex
+++ b/lib/fuzzyurl.ex
@@ -307,10 +307,14 @@ defmodule Fuzzyurl do
       iex> Fuzzyurl.from_string("*.example.com:443", default: "*")
       %Fuzzyurl{fragment: "*", hostname: "*.example.com", password: "*", path: "*", port: "443", protocol: "*", query: "*", username: "*"}
   """
-  @spec from_string(String.t, [tuple]) :: Fuzzyurl.t
+  @spec from_string(String.t, [tuple]) :: Fuzzyurl.t | no_return
   def from_string(string, opts \\ []) when is_binary(string) do
-    {:ok, fuzzy_url} = Strings.from_string(string, opts)
-    fuzzy_url
+    case Strings.from_string(string, opts) do
+      {:ok, fuzzy_url} ->
+        fuzzy_url
+      {:error, msg} ->
+        raise ArgumentError, msg
+    end
   end
 
 end

--- a/test/fuzzyurl_test.exs
+++ b/test/fuzzyurl_test.exs
@@ -37,6 +37,12 @@ defmodule FuzzyurlTest do
       fu = %Fuzzyurl{protocol: "http", hostname: "example.com", path: "/index.html"}
       assert(fu == Fuzzyurl.from_string("http://example.com/index.html"))
     end
+
+    it "raises on invalid input" do
+      assert_raise ArgumentError, fn ->
+        Fuzzyurl.from_string("http:\\\\blah")
+      end
+    end
   end
 
   context "to_string" do


### PR DESCRIPTION
This is a version of #2 that fits in with the cross-language Fuzzyurl interface better.